### PR TITLE
docs: add v0.2 roadmap and implementation specs

### DIFF
--- a/docs/roadmap/v0.2-roadmap.md
+++ b/docs/roadmap/v0.2-roadmap.md
@@ -1,0 +1,435 @@
+# IChingPy v0.2 Roadmap
+
+## Purpose
+
+This roadmap turns the current `ichingpy` codebase into a more reliable, extensible library for:
+
+- I-Ching hexagram generation and interpretation
+- Four Pillars / BaZi calendar calculations
+- Six Lines (六爻) chart construction and future analysis
+
+The current codebase already has a strong domain core. The next milestone should focus on correctness, structured APIs, and a clean separation between domain models, engines, and presentation.
+
+---
+
+## Current state
+
+### Strengths
+
+- Strong typed domain model for:
+  - `Line`
+  - `Trigram`
+  - `Hexagram`
+  - `SexagenaryCycle`
+  - `FourPillars`
+- Existing divination engines:
+  - `IChingDivinationEngine`
+  - `SixLinesDivinationEngine`
+- Good test coverage and fast test suite
+- Documentation already exists for core examples and API
+
+### Main gaps
+
+- Calendar precision is approximate
+- Interpretation output is mostly string rendering, not structured data
+- Six Lines currently builds charts but does not yet analyze them
+- Some construction logic is coupled to a default interpretation engine
+- Random generation is not deterministic-friendly
+- Language handling is global/class-based rather than render-scoped
+
+---
+
+## Product direction
+
+### North star
+
+Make `ichingpy` the most reliable Python library for programmatic I-Ching and Six Lines work.
+
+### v0.2 theme
+
+**Correctness + structured interpretation + implementation-ready architecture**
+
+---
+
+## Milestones
+
+## Milestone 1 — Calendar correctness foundation
+
+### Goal
+
+Replace approximate calendar logic with a dedicated, testable calendar subsystem.
+
+### Why
+
+`FourPillars` currently depends on approximate month boundaries and a hardcoded day reference. This affects both BaZi and datetime-based hexagram generation.
+
+### Scope
+
+- Add a calendar module for solar terms and sexagenary date logic
+- Keep public API backward-compatible where possible
+- Add tests for known edge cases around solar term boundaries
+
+### PR-sized tasks
+
+- [ ] Create `ichingpy.calendar` package skeleton
+- [ ] Add `SolarTerm` model / enum / data representation
+- [ ] Add a `SolarTermsProvider` protocol or interface
+- [ ] Implement a table-driven solar term provider for a fixed supported year range
+- [ ] Add exact lookup for year pillar transitions around Li Chun
+- [ ] Add exact lookup for month pillar transitions around jieqi boundaries
+- [ ] Refactor `FourPillars.get_year_pillar()` to use the calendar provider
+- [ ] Refactor `FourPillars.get_month_pillar()` to use the calendar provider
+- [ ] Add timezone-aware datetime handling rules for calendar conversion
+- [ ] Add regression tests for dates within ±2 days of solar term boundaries
+- [ ] Add docs page for calendar precision and supported range
+
+### Specs
+
+#### New package
+
+Create:
+
+- `src/ichingpy/calendar/__init__.py`
+- `src/ichingpy/calendar/solar_terms.py`
+- `src/ichingpy/calendar/provider.py`
+- `src/ichingpy/calendar/ganzhi.py` if needed
+
+#### Suggested abstractions
+
+```python
+class SolarTermsProvider(Protocol):
+    def get_year_transition(self, year: int) -> datetime: ...
+    def get_month_transitions(self, year: int) -> list[datetime]: ...
+```
+
+or:
+
+```python
+@dataclass(frozen=True)
+class SolarTerm:
+    name: str
+    starts_at: datetime
+```
+
+#### Implementation requirements
+
+- Support timezone-aware `datetime` objects
+- Define one canonical internal timezone policy for comparison
+- Keep `FourPillars.from_datetime(...)` signature stable if possible
+- If exact data is unavailable for a year, raise a clear error instead of silently guessing
+- Keep approximate provider as fallback only if explicitly requested
+
+#### Acceptance criteria
+
+- Dates near Li Chun produce correct year pillar
+- Dates near month-start jieqi produce correct month pillar
+- Existing tests continue passing, except where old behavior was demonstrably wrong
+- New tests document supported year range and failure behavior
+
+---
+
+## Milestone 2 — Structured interpretation API
+
+### Goal
+
+Expose interpretation results as structured data, not only formatted strings.
+
+### Why
+
+Current interpretation flow is centered on `__repr__` and attached mutable interpretation objects. This makes CLI/notebook use pleasant, but limits API, web, storage, and LLM integrations.
+
+### Scope
+
+- Add serialization/export methods
+- Clarify public interpretation accessors
+- Keep string rendering, but stop making it the only machine-usable output
+
+### PR-sized tasks
+
+- [ ] Add `to_dict()` to `Line`, `Trigram`, `Hexagram`
+- [ ] Add `to_dict()` to `FourPillars`
+- [ ] Add `to_dict()` to `SexagenaryCycle`
+- [ ] Add `to_dict()` to `IChingHexagramInterp`
+- [ ] Add `to_dict()` to `SixLineHexagramInterp`
+- [ ] Add `to_dict()` to `SixLineLineInterp`
+- [ ] Add `moving_lines()` helper to I-Ching interpretation
+- [ ] Add `get_judgement()` public tests and docs
+- [ ] Add JSON export helper or document `model_dump()` usage where appropriate
+- [ ] Add example docs for exporting a reading to JSON
+
+### Specs
+
+#### Minimal structured outputs
+
+`Hexagram.to_dict()` should include:
+
+- inner trigram values
+- outer trigram values
+- line values
+- transformed hexagram values
+- interpretation payload if attached
+
+`SixLineHexagramInterp.to_dict()` should include:
+
+- palace
+- lines
+- stem/branch per line
+- relative per line
+- role per line
+- spirit per line if assigned
+- transformed interpretation
+
+`FourPillars.to_dict()` should include:
+
+- year/month/day/hour pillars
+- stem/branch values and labels for each pillar
+
+#### Implementation notes
+
+- Prefer explicit `to_dict()` over relying only on Pydantic internals
+- Decide whether language affects labels in serialized output
+  - recommended: serialize stable enum names/values plus localized labels separately
+- Avoid including transient/private attrs directly
+
+#### Acceptance criteria
+
+- A user can round-trip the important reading data into JSON
+- Notebooks and web apps can consume outputs without parsing `repr()`
+- Tests cover both interpreted and non-interpreted objects
+
+---
+
+## Milestone 3 — Six Lines analysis layer
+
+### Goal
+
+Move Six Lines from chart construction toward chart analysis.
+
+### Why
+
+`SixLinesDivinationEngine` already builds rich charts. The next differentiator is a rule-based analysis engine on top.
+
+### Scope
+
+- Add a chart abstraction for six-line readings
+- Add analysis models and first useful rules
+- Keep rule provenance explicit
+
+### PR-sized tasks
+
+- [ ] Introduce `SixLineChart` model wrapping a `Hexagram` and its `SixLineHexagramInterp`
+- [ ] Add `SixLineAnalysis` result model
+- [ ] Add `SixLineAnalyzer` skeleton
+- [ ] Implement day/month pillar attachment to a chart
+- [ ] Implement void branch (空亡) analysis per line
+- [ ] Implement seasonal strength analysis per line
+- [ ] Implement moving-line extraction
+- [ ] Implement subject/object line extraction
+- [ ] Add rule model with provenance metadata
+- [ ] Add first rule pack for basic strength assessment
+- [ ] Add docs page explaining the analysis pipeline
+
+### Specs
+
+#### Suggested new modules
+
+- `src/ichingpy/divination/six_lines_chart.py`
+- `src/ichingpy/divination/six_lines_analysis.py`
+
+or a subpackage:
+
+- `src/ichingpy/six_lines/__init__.py`
+- `src/ichingpy/six_lines/chart.py`
+- `src/ichingpy/six_lines/analysis.py`
+- `src/ichingpy/six_lines/rules.py`
+
+#### Core models
+
+```python
+class SixLineChart(BaseModel):
+    hexagram: Hexagram
+    interpretation: SixLineHexagramInterp
+    month_pillar: SexagenaryCycle | None = None
+    day_pillar: SexagenaryCycle | None = None
+```
+
+```python
+class SixLineRule(BaseModel):
+    code: str
+    name: str
+    school: str | None = None
+    description: str
+```
+
+```python
+class SixLineAnalysis(BaseModel):
+    moving_line_indexes: list[int]
+    subject_line_index: int | None
+    object_line_index: int | None
+    void_line_indexes: list[int]
+    line_strengths: dict[int, str]
+    applied_rules: list[SixLineRule]
+```
+
+#### Implementation requirements
+
+- Do not bury analysis only in strings
+- Keep analysis reproducible from chart + calendar context
+- Store rule provenance (`school`, `source`, `notes`) where traditions differ
+- Start with deterministic, inspectable rules only
+
+#### Acceptance criteria
+
+- Given a chart plus day/month pillars, analyzer returns a structured analysis object
+- Existing chart-construction behavior remains unchanged
+- New tests verify void branches, moving lines, and role extraction
+
+---
+
+## Milestone 4 — Architecture cleanup: construction vs engines vs rendering
+
+### Goal
+
+Reduce coupling between domain construction, interpretation engines, and presentation.
+
+### Why
+
+`Hexagram.from_lines()` currently auto-applies `IChingDivinationEngine`. This is convenient but couples model construction to one interpretation pipeline.
+
+### Scope
+
+- Preserve backward compatibility
+- Introduce explicit engine application patterns
+- Move toward render-time language selection
+
+### PR-sized tasks
+
+- [ ] Audit all constructors that attach interpretations implicitly
+- [ ] Add `Hexagram.empty()` or `Hexagram.from_lines(..., attach_interpretation: bool = True)` transition path
+- [ ] Add explicit `IChingDivinationEngine.execute()` usage examples in docs
+- [ ] Add `render(lang="zh" | "en")` or equivalent presentation helpers
+- [ ] Reduce reliance on global `set_language()` for new APIs
+- [ ] Deprecate implicit interpretation attachment only after docs and migration path are ready
+
+### Specs
+
+#### Recommended transition
+
+Do not break current API immediately.
+
+Phase 1:
+- keep current behavior
+- add explicit alternatives
+
+Example:
+
+```python
+hexagram = Hexagram.from_lines(lines)
+engine = IChingDivinationEngine()
+engine.execute(hexagram)
+```
+
+Phase 2:
+- introduce keyword opt-out:
+
+```python
+Hexagram.from_lines(lines, attach_interpretation=False)
+```
+
+Phase 3:
+- consider making pure construction the default in a later major version
+
+#### Acceptance criteria
+
+- Users can construct pure domain objects without triggering an engine
+- Docs show both simple and explicit usage
+- No breaking change in v0.2 unless clearly documented
+
+---
+
+## Milestone 5 — Deterministic generation and developer ergonomics
+
+### Goal
+
+Make random generation reproducible and improve contributor workflow.
+
+### Why
+
+The library uses randomness in several generation methods. Deterministic hooks make tests, docs, and examples more stable.
+
+### Scope
+
+- Add RNG injection
+- Improve repo hygiene and CI quality checks
+
+### PR-sized tasks
+
+- [ ] Add optional `rng` parameter to `Hexagram.from_three_coins()`
+- [ ] Add optional `rng` parameter to `Hexagram.from_yarrow_stalks()`
+- [ ] Add optional `rng` parameter to `Hexagram.random()` and `Line.random()`
+- [ ] Add deterministic tests for seeded generation
+- [ ] Add Ruff CI job
+- [ ] Add type-check CI job
+- [ ] Add docs build CI job
+- [ ] Review `.gitignore` for local tool artifacts
+
+### Specs
+
+#### RNG API
+
+Use `random.Random`-compatible interface:
+
+```python
+def from_three_coins(cls, rng: random.Random | None = None) -> Self:
+    rng = rng or random
+```
+
+#### Acceptance criteria
+
+- Same seed gives same generated hexagram
+- Existing no-argument behavior remains unchanged
+- CI catches lint/type/docs regressions
+
+---
+
+## Suggested implementation order
+
+1. Milestone 1 — Calendar correctness foundation
+2. Milestone 2 — Structured interpretation API
+3. Milestone 5 — Deterministic generation and developer ergonomics
+4. Milestone 3 — Six Lines analysis layer
+5. Milestone 4 — Architecture cleanup
+
+Reason:
+- correctness first
+- then export/API usability
+- then deeper analysis features
+- then larger architectural cleanup
+
+---
+
+## Candidate v0.2 release scope
+
+A realistic v0.2 could include:
+
+- calendar provider foundation
+- structured `to_dict()` exports
+- deterministic RNG support
+- initial `SixLineChart` + `SixLineAnalyzer` skeleton
+
+Defer to v0.3+:
+
+- broader rule packs
+- breaking constructor cleanup
+- richer localization redesign
+- web/API demo app
+
+---
+
+## Notes for implementation agents
+
+- Preserve current public behavior unless a task explicitly says otherwise
+- Prefer small PRs with tests and docs
+- Use existing naming style and module layout where possible
+- If a rule has multiple traditional variants, encode provenance instead of choosing silently
+- Do not hardcode more calendar approximations unless explicitly marked as fallback behavior

--- a/docs/roadmap/v0.2-roadmap.md
+++ b/docs/roadmap/v0.2-roadmap.md
@@ -61,20 +61,22 @@ Replace approximate calendar logic with a dedicated, testable calendar subsystem
 
 ### Why
 
-`FourPillars` currently depends on approximate month boundaries and a hardcoded day reference. This affects both BaZi and datetime-based hexagram generation.
+`FourPillars` currently depends on approximate month boundaries and a hardcoded day reference. This affects both BaZi and datetime-based hexagram generation. Using a dedicated calendar library such as `tyme4py` should reduce implementation risk here.
 
 ### Scope
 
 - Add a calendar module for solar terms and sexagenary date logic
+- Evaluate and likely adopt [`tyme4py`](https://github.com/6tail/tyme4py) as the calendar backend/provider instead of building all solar-term logic from scratch
 - Keep public API backward-compatible where possible
 - Add tests for known edge cases around solar term boundaries
 
 ### PR-sized tasks
 
 - [ ] Create `ichingpy.calendar` package skeleton
+- [ ] Evaluate `tyme4py` API fit for solar terms, lunar calendar, ganzhi, and timezone handling
 - [ ] Add `SolarTerm` model / enum / data representation
 - [ ] Add a `SolarTermsProvider` protocol or interface
-- [ ] Implement a table-driven solar term provider for a fixed supported year range
+- [ ] Implement a `tyme4py`-backed provider behind the internal calendar interface
 - [ ] Add exact lookup for year pillar transitions around Li Chun
 - [ ] Add exact lookup for month pillar transitions around jieqi boundaries
 - [ ] Refactor `FourPillars.get_year_pillar()` to use the calendar provider
@@ -113,6 +115,8 @@ class SolarTerm:
 
 #### Implementation requirements
 
+- Prefer `tyme4py` for calendar calculations if it covers the required solar-term and ganzhi use cases
+- Hide `tyme4py` behind an internal provider interface so the rest of `ichingpy` does not depend directly on its API shape
 - Support timezone-aware `datetime` objects
 - Define one canonical internal timezone policy for comparison
 - Keep `FourPillars.from_datetime(...)` signature stable if possible


### PR DESCRIPTION
This PR adds a v0.2 roadmap for ichingpy with:

- milestone breakdown
- PR-sized checkbox tasks
- implementation specs for agent execution
- calendar backend direction using tyme4py behind an internal provider interface

File added:
- docs/roadmap/v0.2-roadmap.md